### PR TITLE
Honor Sphinx sorting order

### DIFF
--- a/src/mnshankar/Sphinxql/Sphinxql.php
+++ b/src/mnshankar/Sphinxql/Sphinxql.php
@@ -42,13 +42,29 @@ class Sphinxql
             return $matchids;
         }        
         if (class_exists($name))
-        {            
-             $result = call_user_func_array($name . "::whereIn", array($key, $matchids))->get();          
-        }
-        else 
         {
-            $result = \DB::table($name)->whereIn($key, $matchids)->get();
-        }        
+            if ( empty($matchids) )
+            {
+                // If no matched ids don't bother doing a query, just return an empty collection.
+                $result = new \Illuminate\Database\Eloquent\Collection();
+            }
+            else
+            {
+                $result = call_user_func_array($name . "::whereIn", array($key, $matchids))->orderByRaw(\DB::raw('FIELD(`' . $key . '`, ' . implode(',', $matchids) . ')'))->get();
+            }
+        }
+        else
+        {
+            if ( empty($matchids) )
+            {
+                // If no matched ids don't bother doing a query, just return an empty array..
+                $result = array();
+            }
+            else
+            {
+                $result = \DB::table($name)->whereIn($key, $matchids)->orderByRaw(\DB::raw('FIELD(`' . $key . '`, ' . implode(',', $matchids) . ')'))->get();
+            }
+        }    
         return $result;
     }    
     /**


### PR DESCRIPTION
Using WHERE IN(3,2,1) to fetch rows from MySQL does not guarantee the sorting order is kept. In order to ensure this we have to explicitly sort by the $key field and provide the ids in the order they should be sorted in.

Since Eloquent does not support ordering by a method call we have to use orderByRaw() - which means Laravel won't handle empty matches for us like it does with the whereIn call by generating WHERE 0 = 1. Therefore I added an empty check as well which simply returns an empty collection or array. This also saves a query in case Sphinx returns no results.
